### PR TITLE
Fix detection of dependency for making kernel c file

### DIFF
--- a/kernel_module/CMakeLists.txt
+++ b/kernel_module/CMakeLists.txt
@@ -33,7 +33,7 @@ add_custom_target("${SELF_C}.target"
 
 add_custom_command(
   OUTPUT "${SELF_C}"
-  DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${SELF}"
+  DEPENDS "${SELF}" "${ELF}"
   COMMAND xxd -i "${SELF}" "${SELF_C}"
   COMMENT "Converting ${SELF} to ${SELF_C}"
 )


### PR DESCRIPTION
if project uses vitasdk's `vita.cmake`, rebuilding result would be wrong
after [patch][1]

[1]: https://github.com/vitasdk/vita-toolchain/commit/4545e75e6